### PR TITLE
Use PIP_CONFIG_FILE in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - pip install -U pip
   - pip install codecov
 install:
+  - export PIP_CONFIG_FILE=$(pwd)/pip.conf
   - pip install -r requirements.txt -r dev-requirements.txt # install package + test dependencies
 script: pytest # run tests
 after_success:


### PR DESCRIPTION
The requirements files depended on a CERN-specific library. This PR fixes the build process.